### PR TITLE
Some protos might not have a package name, and that's okay.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -174,7 +174,7 @@ Compiler.prototype.compileDescriptor = function(descriptor) {
 Compiler.prototype.compileEnum = function(enumDesc, pkg, descriptor) {
   var enumDescriptor = goog.enumDescriptorProto,
       name = enumDesc[enumDescriptor.NAME],
-      fullName = pkg + "." + name,
+      fullName = pkg ? pkg + "." + name : name,
       Enum = require('./enum').Enum,
       nenum, obj;
 


### PR DESCRIPTION
protob